### PR TITLE
Add gzip option (enabled by default)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = "S3-${element(local.domains, count.index)}"
+    compress         = "${var.enable_gzip}"
 
     forwarded_values {
       query_string = false

--- a/variables.tf
+++ b/variables.tf
@@ -14,3 +14,9 @@ variable "health_check_alarm_sns_topics" {
   default     = []
   description = "A list of SNS topics to notify whenever the health check fails or comes back to normal"
 }
+
+variable "enable_gzip" {
+  type        = "string"
+  default     = true
+  description = "Whether to make CloudFront automatically compress content for web requests that include `Accept-Encoding: gzip` in the request header"
+}


### PR DESCRIPTION
## Test plan
Tried a `terraform plan` locally for the buildo.io website. It effectively sets `compress` to `true`.