### PR TITLE
Fix redirect on the Apex domain to WWW domain

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,15 @@ data "template_file" "bucket_policy" {
   }
 }
 
+data "template_file" "redirect_bucket_policy" {
+  template = "${file("${path.module}/website_bucket_policy.json")}"
+
+  vars {
+    bucket = "${var.domain}"
+    iam_arn= "${aws_cloudfront_origin_access_identity.orig_access_ident.iam_arn}"
+  }
+}
+
 resource "aws_s3_bucket" "main" {
   bucket = "${local.www_domain}"
   policy   = "${data.template_file.bucket_policy.rendered}"
@@ -42,6 +51,7 @@ resource "aws_s3_bucket" "main" {
 
 resource "aws_s3_bucket" "redirect" {
   bucket = "${var.domain}"
+  policy   = "${data.template_file.redirect_bucket_policy.rendered}"
 
   website = {
     redirect_all_requests_to = "${aws_s3_bucket.main.id}"

--- a/website_bucket_policy.json
+++ b/website_bucket_policy.json
@@ -1,6 +1,6 @@
 {
   "Version": "2008-10-17",
-  "Id": "PolicyForCloudFrontPrivateContent",
+  "Id": "PolicyForCloudFrontPrivateContent-${bucket}",
   "Statement": [
     {
       "Sid": "1",


### PR DESCRIPTION
This should fix issue https://github.com/buildo/terraform-aws-website/issues/4, the regression caused by my previous PR. 

After re-applying I again get the expected redirect from the naked domain to the WWW domain.

Hopefully it works for you as well. Since I modified the ID of the policy (so it's unique, just in case this matters for AWS for this policy type), the plan should show changes to 2 resources.