### PR TITLE
Fix compatibility issues with Terraform 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ data "aws_route53_zone" "zone" {
 resource "aws_s3_bucket" "main" {
   bucket = "${local.www_domain}"
 
-  website = {
+  website {
     index_document = "index.html"
     error_document = "index.html"
   }
@@ -33,7 +33,7 @@ resource "aws_s3_bucket" "main" {
 resource "aws_s3_bucket" "redirect" {
   bucket = "${var.domain}"
 
-  website = {
+  website {
     redirect_all_requests_to = "${aws_s3_bucket.main.id}"
   }
 }
@@ -169,7 +169,7 @@ resource "aws_cloudwatch_metric_alarm" "health_check_alarm" {
   alarm_actions       = "${var.health_check_alarm_sns_topics}"
   treat_missing_data  = "breaching"
 
-  dimensions {
-    HealthCheckId = "${aws_route53_health_check.health_check.id}"
+  dimensions = {
+    HealthCheckId = "${aws_route53_health_check.health_check.0.id}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -124,16 +124,16 @@ resource "aws_cloudfront_distribution" "cdn" {
   }
 
   custom_error_response {
-    error_code = 403
-    response_code = 200
-    response_page_path = "/index.html"
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
     error_caching_min_ttl = 300
   }
 
   custom_error_response {
-    error_code = 404
-    response_code = 200
-    response_page_path = "/index.html"
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
     error_caching_min_ttl = 300
   }
 }


### PR DESCRIPTION
Closes [#2521102](https://buildo.kaiten.io/space/[object Object]/card/2521102)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #6

Fixed compatibility issues with Terraform v0.12 while retaining backwards compatibilty at least for v0.11

### tests performed
- `terraform init` (for both v0.11.14 and v0.12.6) works correctly against a test deployment;
- `terraform plan` (for both v0.11.14 and v0.12.6) works correctly against an existing deployment, requiring no changes to be applied.